### PR TITLE
Don't pass v2 keystone_url to monasca-keystone

### DIFF
--- a/monasca_installer/monasca_deps.yml
+++ b/monasca_installer/monasca_deps.yml
@@ -2,7 +2,7 @@
   hosts: keystone_host
   sudo: yes
   roles:
-    - {role: monasca-keystone, keystone_url: "http://{{keystone_host}}:35357/v2.0", tags: [keystone]}  # uses keystone v2 still
+    - {role: monasca-keystone, tags: [keystone]}
 
 - name: Installs the Monasca DBs, kafka and other core dependencies
   hosts: monasca

--- a/monasca_installer/monasca_deps.yml
+++ b/monasca_installer/monasca_deps.yml
@@ -1,5 +1,5 @@
-- name: Install monasca keystone roles and endpoint on a keystone host
-  hosts: keystone_host
+- name: Install monasca keystone roles and endpoint into keystone
+  hosts: monasca_master
   sudo: yes
   roles:
     - {role: monasca-keystone, tags: [keystone]}


### PR DESCRIPTION
monasca-keystone now changes a v3 URL to v2 if required
This change requires the new monasca-keystone role. Update
if monasca-keystone fails with a 404