### PR TITLE
Set keystone_project_admin user to 'mini-mon'

### DIFF
--- a/monasca_installer/vagrant_config.yml
+++ b/monasca_installer/vagrant_config.yml
@@ -91,7 +91,7 @@ all_config:
   keystone_endpoint: {host: '{{ monasca_api_host }}', name: monasca}
   keystone_host: 192.168.10.5
   keystone_project: test
-  keystone_project_admin: monasca-agent
+  keystone_project_admin: mini-mon
   keystone_project_admin_password: password
   keystone_monasca_agent_password: password
   keystone_url: http://{{keystone_host}}:35357/v3


### PR DESCRIPTION
The keystone_project_admin user was incorrectly set to
monasca-agent, causing the default e-mail notification
step in Ansible to fail with "HTTPBadRequest: ERROR: None"