### PR TITLE
Fix python/pip prerequisites

### DIFF
--- a/monasca_installer/monasca_deps.yml
+++ b/monasca_installer/monasca_deps.yml
@@ -1,3 +1,17 @@
+- name: Install python/pip prerequisites
+  hosts: monasca
+  sudo: yes
+  tasks:
+    - name: Install python setup tools
+      apt: name=python-setuptools state=present
+    - name: Install pip from easy_install
+      easy_install: name=pip
+    - name: Install packages to allow pip to compile extensions as needed
+      apt: name={{item}} state=present
+      with_items:
+        - python-dev
+        - libssl-dev
+
 - name: Install monasca keystone roles and endpoint into keystone
   hosts: monasca_master
   sudo: yes
@@ -11,16 +25,6 @@
   tasks:
     - name: Install postfix, needed by notification engine
       apt: name=postfix state=present
-    - name: Install python setup tools
-      apt: name=python-setuptools state=present
-    - name: Install pip from easy_install
-      easy_install: name=pip
-    - name: Install packages to allow pip to compile extensions as needed
-      apt: name={{item}} state=present
-      with_items:
-        - python-dev
-        - libssl-dev
-        - libcrypto++-dev
   roles:
     - {role: zookeeper, tags: [zookeeper]}
     - {role: kafka, tags: [kafka]}


### PR DESCRIPTION
ansible-monasca-keystone pull #7 works great on mini-mon, but causes
the monasca_installer to fail because the monasca-keystone role is run
_before_ pip is installed.  What this fix does is move these prereqs
to a separate step in advance of monasca-keystone so that pip is
available from the start.