### PR TITLE
Adapted Monasca agent sections and influxdb section in example configuration

### DIFF
--- a/monasca_installer/build-ansible-files.py
+++ b/monasca_installer/build-ansible-files.py
@@ -105,9 +105,9 @@ class AnsibleConfigGen(object):
             if service['service'] != 'monasca':
                 # skip the monasca group vars, it already exists
                 if service['service'] == 'multi-service':
-                    agent_config['monasca_agent']['service'] = ""
+                    agent_config['monasca_agent_service'] = ""
                 else:
-                    agent_config['monasca_agent']['service'] = service['service']
+                    agent_config['monasca_agent_service'] = service['service']
                 self.save_group(agent_config, service['service'])
 
         # Build the files in host_vars/

--- a/monasca_installer/monasca_config.yml.example
+++ b/monasca_installer/monasca_config.yml.example
@@ -165,7 +165,7 @@ smtp_host: localhost
 wsrep_cluster_name: monasca
 
 influxdb_replication_factor: 3
-influxdb_version: 0.9.0-rc
+influxdb_version: 0.9.0-rc27
 influxdb_raft_port: 9090
 influxdb_hostname: "{{ inventory_hostname }}"
 

--- a/monasca_installer/monasca_config.yml.example
+++ b/monasca_installer/monasca_config.yml.example
@@ -154,11 +154,10 @@ hosts:
     kafka_id: 2
 
 #The monasca_agent for monasca
-monasca_agent:
-  user: monasca-agent
-  password: "{{keystone_monasca_agent_password}}"
-  project: "{{keystone_project}}"
-  service: monitoring
+monasca_agent_user: monasca-agent
+monasca_agent_password: "{{keystone_monasca_agent_password}}"
+monasca_agent_project: "{{keystone_project}}"
+monasca_agent_service: monitoring
 
 persister_influxdb_user: mon_persister
 persister_influxdb_password: PLEASE-GENERATE
@@ -215,12 +214,9 @@ workers_config:
     replication_factor: '{{influxdb_replication_factor}}'
 
 agent_config:
-  monasca_agent:
   # The service will be populated by monitored_services service.
   # The monasca_agent dictionary is output in the service group_var file.
-    user: monasca-agent
-    password: "{{keystone_monasca_agent_password}}"
-    project: "{{keystone_project}}"
-    service: monitoring
-
-
+  monasca_agent_user: monasca-agent
+  monasca_agent_password: "{{keystone_monasca_agent_password}}"
+  monasca_agent_project: "{{keystone_project}}"
+  monasca_agent_service: monitoring

--- a/monasca_installer/monasca_config.yml.example
+++ b/monasca_installer/monasca_config.yml.example
@@ -112,8 +112,14 @@ all_config:
   keystone_monasca_agent_password: password
   keystone_url: http://{{keystone_host}}:35357/v3
   keystone_users:
-    mini-mon: {password: "{{keystone_project_admin_password}}", role: monasca-user, project: "{{keystone_project}}"}
-    monasca-agent: {password: "{{keystone_monasca_agent_password}}", role: monasca-agent, project: "{{keystone_project}}"}
+    - username: mini-mon
+      password: "{{keystone_project_admin_password}}"
+      role: monasca-user
+      project: "{{keystone_project}}"
+    - username: monasca-agent
+      password: "{{keystone_monasca_agent_password}}"
+      role: monasca-agent
+      project: "{{keystone_project}}"
 
 monitored_services:
   # Hosts by service to install the monasca-agent.  One agent is installed per host.

--- a/monasca_installer/vagrant_config.yml
+++ b/monasca_installer/vagrant_config.yml
@@ -96,8 +96,14 @@ all_config:
   keystone_monasca_agent_password: password
   keystone_url: http://{{keystone_host}}:35357/v3
   keystone_users:
-    mini-mon: {password: "{{keystone_project_admin_password}}", role: monasca-user, project: "{{keystone_project}}"}
-    monasca-agent: {password: "{{keystone_monasca_agent_password}}", role: monasca-agent, project: "{{keystone_project}}"}
+    - username: mini-mon
+      password: "{{keystone_project_admin_password}}"
+      role: monasca-user
+      project: "{{keystone_project}}"
+    - username: monasca-agent
+      password: "{{keystone_monasca_agent_password}}"
+      role: monasca-agent
+      project: "{{keystone_project}}"
 
 monitored_services:
   # Hosts by service to install the monasca-agent.  One agent is installed per host.

--- a/monasca_installer/vagrant_config.yml
+++ b/monasca_installer/vagrant_config.yml
@@ -146,7 +146,7 @@ wsrep_node_name: '{{inventory_hostname}}'
 wsrep_sst_receive_address: '{{inventory_hostname}}'
 
 influxdb_replication_factor: 3
-influxdb_version: 0.9.0-rc
+influxdb_version: 0.9.0-rc27
 influxdb_raft_port: 9090
 influxdb_hostname: "{{ inventory_hostname }}"
 

--- a/monasca_installer/vagrant_config.yml
+++ b/monasca_installer/vagrant_config.yml
@@ -133,11 +133,10 @@ hosts:
     kafka_id: 2
 
 #The monasca_agent for monasca
-monasca_agent:
-  user: monasca-agent
-  password: "{{keystone_monasca_agent_password}}"
-  project: "{{keystone_project}}"
-  service: monitoring
+monasca_agent_user: monasca-agent
+monasca_agent_password: "{{keystone_monasca_agent_password}}"
+monasca_agent_project: "{{keystone_project}}"
+monasca_agent_service: monitoring
 
 persister_influxdb_user: mon_persister
 persister_influxdb_password: password
@@ -196,10 +195,9 @@ workers_config:
     replication_factor: '{{influxdb_replication_factor}}'
 
 agent_config:
-  monasca_agent:
   # The service will be populated by monitored_services service.
   # The monasca_agent dictionary is output in the service group_var file.
-    user: monasca-agent
-    password: "{{keystone_monasca_agent_password}}"
-    project: "{{keystone_project}}"
-    service: monitoring
+  monasca_agent_user: monasca-agent
+  monasca_agent_password: "{{keystone_monasca_agent_password}}"
+  monasca_agent_project: "{{keystone_project}}"
+  monasca_agent_service: monitoring


### PR DESCRIPTION
The ansible role for installing the monasca agent changed the naming of
the configuration variables in
hpcloud-mon/ansible-monasca-agent@692b6b092f90c5628624d67ffa1942816d0b18cd